### PR TITLE
fix: add missing fstream header include

### DIFF
--- a/src/middleware/serve_static_provider.cpp
+++ b/src/middleware/serve_static_provider.cpp
@@ -1,6 +1,7 @@
 #include "expresscpp/middleware/serve_static_provider.hpp"
 
 #include <filesystem>
+#include <fstream>
 
 #include "expresscpp/console.hpp"
 #include "expresscpp/impl/session.hpp"


### PR DESCRIPTION
This is required to build expresscpp with GCC11+

Signed-off-by: Pascal Bach <pascal.bach@siemens.com>